### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 env:
   global:
+    - coverage=false
     - CC_TEST_REPORTER_ID=f4be619f64012832252ac47ada6732017a9415075d3984f7d5db060a313f9a04
 
 language: php
@@ -7,13 +8,12 @@ language: php
 matrix:
   include:
   - php: 7.1
+    env: coverage=true
   - php: 7.2
+  - php: 7.3
+  - php: 7.4
 
 sudo: false
-
-addons:
-  code_climate:
-    repo_token: f4be619f64012832252ac47ada6732017a9415075d3984f7d5db060a313f9a04
 
 install:
     - composer install
@@ -21,10 +21,10 @@ install:
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
-  - ./cc-test-reporter before-build
+  - if [[ $coverage = 'true' ]]; then ./cc-test-reporter before-build; fi
 
 script:
   - vendor/bin/phpunit --coverage-clover build/logs/clover.xml --configuration phpunit.xml
 
 after_script:
-  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+    - if [[ $coverage = 'true' ]]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "php": ">=7.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^6"
+    "phpunit/phpunit": "^6 || ^7 || ^8 || ^9"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
# Changed log
- Using current setting about `codeclimate` service integration during Travis CI build.
- Defining different PHPUnit versions to support different PHP version tests.
- The latest Travis CI build log is available [here](https://travis-ci.org/open-source-contributions/paginator/jobs/648103826) on my forked repository.